### PR TITLE
feat: spawn configs can now rotate the prefab.

### DIFF
--- a/Valheim.CustomRaids/Valheim.CustomRaids/Configuration/ConfigTypes/RaidEventConfigurationFile.cs
+++ b/Valheim.CustomRaids/Valheim.CustomRaids/Configuration/ConfigTypes/RaidEventConfigurationFile.cs
@@ -223,6 +223,11 @@ namespace Valheim.CustomRaids.Configuration.ConfigTypes
 
         public ConfigurationEntry<float> OceanDepthMax = new(0, "Maximum ocean depth to spawn in. Ignored if min == max.");
 
+        public ConfigurationEntry<float> RotationX = new(0, "Rotate the spawned object on the x axis. Defaults to 0");
+
+        public ConfigurationEntry<float> RotationY = new(0, "Rotate the spawned object on the y axis. Defaults to 0");
+
+        public ConfigurationEntry<float> RotationZ = new(0, "Rotate the spawned object on the z axis. Defaults to 0");
         #endregion
     }
 

--- a/Valheim.CustomRaids/Valheim.CustomRaids/Spawns/Modifiers/General/SpawnModifierRotatePrefab.cs
+++ b/Valheim.CustomRaids/Valheim.CustomRaids/Spawns/Modifiers/General/SpawnModifierRotatePrefab.cs
@@ -1,0 +1,32 @@
+﻿using Valheim.CustomRaids.Core;
+
+namespace Valheim.CustomRaids.Spawns.Modifiers.General;
+
+public class SpawnModifierRotatePrefab : ISpawnModifier
+{
+    private static SpawnModifierRotatePrefab _instance;
+
+    public static SpawnModifierRotatePrefab Instance
+    {
+        get
+        {
+            return _instance ??= new SpawnModifierRotatePrefab();
+        }
+    }
+
+    public void Modify(SpawnContext context)
+    {
+        if (context.Spawn is null)
+        {
+            return;
+        }
+
+        float rotationX = context.Config.RotationX.Value;
+        float rotationY = context.Config.RotationY.Value;
+        float rotationZ = context.Config.RotationZ.Value;
+#if DEBUG
+        Log.LogDebug($"Rotating object: x{rotationX}, y{rotationY}, z{rotationZ}");
+#endif
+        context.Spawn.transform.Rotate(rotationX, rotationY, rotationZ);
+    }
+}

--- a/Valheim.CustomRaids/Valheim.CustomRaids/Spawns/SpawnModificationManager.cs
+++ b/Valheim.CustomRaids/Valheim.CustomRaids/Spawns/SpawnModificationManager.cs
@@ -15,6 +15,7 @@ namespace Valheim.CustomRaids.Spawns
         static SpawnModificationManager()
         {
             SpawnModifiers.Add(SpawnModifierSetFaction.Instance);
+            SpawnModifiers.Add(SpawnModifierRotatePrefab.Instance);
 
             SpawnModifiers.Add(SpawnModifierLoaderCLLC.BossAffix);
             SpawnModifiers.Add(SpawnModifierLoaderCLLC.ExtraEffect);


### PR DESCRIPTION
Adds the ability to change the rotation of a prefab after it has spawned. Useful for when you are spawning non-monster prefabs like wall pieces.